### PR TITLE
Prototype iOS specific (maps like) design elements

### DIFF
--- a/DispensaryModel.xcdatamodeld/DispensaryModel.xcdatamodel/contents
+++ b/DispensaryModel.xcdatamodeld/DispensaryModel.xcdatamodel/contents
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Dispensary" representedClassName="Dispensary" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String"/>
+        <attribute name="city" optional="YES" attributeType="String"/>
+        <attribute name="isNYC" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isTemporaryDeliveryOnly" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="website" optional="YES" attributeType="String"/>
+        <attribute name="zipCode" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/offdispmap.xcodeproj/project.pbxproj
+++ b/offdispmap.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		47CA9C602C31D73F00C27BA8 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA9C5F2C31D73F00C27BA8 /* NetworkManager.swift */; };
 		D3A3CD122C42CED800060C53 /* DispensaryModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D3A3CD102C42CED800060C53 /* DispensaryModel.xcdatamodeld */; };
 		D3A3CD142C42D06A00060C53 /* ContentViewiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A3CD132C42D06900060C53 /* ContentViewiOS.swift */; };
+		D3A3CD162C44C20400060C53 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A3CD152C44C20400060C53 /* MainViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		47CA9C5F2C31D73F00C27BA8 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		D3A3CD112C42CED800060C53 /* DispensaryModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DispensaryModel.xcdatamodel; sourceTree = "<group>"; };
 		D3A3CD132C42D06900060C53 /* ContentViewiOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentViewiOS.swift; sourceTree = "<group>"; };
+		D3A3CD152C44C20400060C53 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,7 @@
 				4743D49B2C387E3400183E19 /* LocationManager.swift */,
 				478CFA762C27597C008C9CC5 /* logger.swift */,
 				471EBF202C1F48C00016E689 /* MapView.swift */,
+				D3A3CD152C44C20400060C53 /* MainViewModel.swift */,
 				47CA9C5F2C31D73F00C27BA8 /* NetworkManager.swift */,
 				4700608A2C1F18C4008B3692 /* offdispmapApp.swift */,
 				470060902C1F18C5008B3692 /* Preview Content */,
@@ -315,6 +318,7 @@
 				4743D49C2C387E3400183E19 /* LocationManager.swift in Sources */,
 				D3A3CD122C42CED800060C53 /* DispensaryModel.xcdatamodeld in Sources */,
 				4700608B2C1F18C4008B3692 /* offdispmapApp.swift in Sources */,
+				D3A3CD162C44C20400060C53 /* MainViewModel.swift in Sources */,
 				47CA9C602C31D73F00C27BA8 /* NetworkManager.swift in Sources */,
 				471EBF252C1F936E0016E689 /* DispensaryRow.swift in Sources */,
 				47CA9C5E2C31D4E400C27BA8 /* DataParser.swift in Sources */,

--- a/offdispmap.xcodeproj/project.pbxproj
+++ b/offdispmap.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		471EBF1D2C1F370E0016E689 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 471EBF1C2C1F370E0016E689 /* SwiftSoup */; };
 		471EBF212C1F48C00016E689 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471EBF202C1F48C00016E689 /* MapView.swift */; };
 		471EBF252C1F936E0016E689 /* DispensaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471EBF242C1F936E0016E689 /* DispensaryRow.swift */; };
-		4743D4942C38691900183E19 /* DispensaryModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4743D4922C38691900183E19 /* DispensaryModel.xcdatamodeld */; };
 		4743D4962C3869B600183E19 /* Dispensary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4743D4952C3869B600183E19 /* Dispensary+CoreDataClass.swift */; };
 		4743D4982C386A1900183E19 /* Dispensary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4743D4972C386A1900183E19 /* Dispensary+CoreDataProperties.swift */; };
 		4743D49A2C386A5000183E19 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4743D4992C386A5000183E19 /* CoreDataManager.swift */; };
@@ -28,6 +27,8 @@
 		47CA9C5C2C31D4AF00C27BA8 /* DispensaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA9C5B2C31D4AF00C27BA8 /* DispensaryModel.swift */; };
 		47CA9C5E2C31D4E400C27BA8 /* DataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA9C5D2C31D4E400C27BA8 /* DataParser.swift */; };
 		47CA9C602C31D73F00C27BA8 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA9C5F2C31D73F00C27BA8 /* NetworkManager.swift */; };
+		D3A3CD122C42CED800060C53 /* DispensaryModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D3A3CD102C42CED800060C53 /* DispensaryModel.xcdatamodeld */; };
+		D3A3CD142C42D06A00060C53 /* ContentViewiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A3CD132C42D06900060C53 /* ContentViewiOS.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,7 +61,6 @@
 		470060A72C1F18C5008B3692 /* offdispmapUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = offdispmapUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		471EBF202C1F48C00016E689 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		471EBF242C1F936E0016E689 /* DispensaryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispensaryRow.swift; sourceTree = "<group>"; };
-		4743D4932C38691900183E19 /* DispensaryModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DispensaryModel.xcdatamodel; sourceTree = "<group>"; };
 		4743D4952C3869B600183E19 /* Dispensary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dispensary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4743D4972C386A1900183E19 /* Dispensary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dispensary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4743D4992C386A5000183E19 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
@@ -71,6 +71,8 @@
 		47CA9C5B2C31D4AF00C27BA8 /* DispensaryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispensaryModel.swift; sourceTree = "<group>"; };
 		47CA9C5D2C31D4E400C27BA8 /* DataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataParser.swift; sourceTree = "<group>"; };
 		47CA9C5F2C31D73F00C27BA8 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		D3A3CD112C42CED800060C53 /* DispensaryModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DispensaryModel.xcdatamodel; sourceTree = "<group>"; };
+		D3A3CD132C42D06900060C53 /* ContentViewiOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentViewiOS.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,8 +124,10 @@
 		470060892C1F18C4008B3692 /* offdispmap */ = {
 			isa = PBXGroup;
 			children = (
+				D3A3CD102C42CED800060C53 /* DispensaryModel.xcdatamodeld */,
 				4700608E2C1F18C5008B3692 /* Assets.xcassets */,
 				4700608C2C1F18C4008B3692 /* ContentView.swift */,
+				D3A3CD132C42D06900060C53 /* ContentViewiOS.swift */,
 				4743D4992C386A5000183E19 /* CoreDataManager.swift */,
 				47CA9C5D2C31D4E400C27BA8 /* DataParser.swift */,
 				47CA9C592C303D0B00C27BA8 /* DeveloperView.swift */,
@@ -131,7 +135,6 @@
 				4743D4972C386A1900183E19 /* Dispensary+CoreDataProperties.swift */,
 				478CFA742C275729008C9CC5 /* DispensaryData.swift */,
 				47CA9C5B2C31D4AF00C27BA8 /* DispensaryModel.swift */,
-				4743D4922C38691900183E19 /* DispensaryModel.xcdatamodeld */,
 				471EBF242C1F936E0016E689 /* DispensaryRow.swift */,
 				4743D49B2C387E3400183E19 /* LocationManager.swift */,
 				478CFA762C27597C008C9CC5 /* logger.swift */,
@@ -304,11 +307,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3A3CD142C42D06A00060C53 /* ContentViewiOS.swift in Sources */,
 				4700608D2C1F18C4008B3692 /* ContentView.swift in Sources */,
 				47CA9C5C2C31D4AF00C27BA8 /* DispensaryModel.swift in Sources */,
 				471EBF212C1F48C00016E689 /* MapView.swift in Sources */,
 				4743D49A2C386A5000183E19 /* CoreDataManager.swift in Sources */,
 				4743D49C2C387E3400183E19 /* LocationManager.swift in Sources */,
+				D3A3CD122C42CED800060C53 /* DispensaryModel.xcdatamodeld in Sources */,
 				4700608B2C1F18C4008B3692 /* offdispmapApp.swift in Sources */,
 				47CA9C602C31D73F00C27BA8 /* NetworkManager.swift in Sources */,
 				471EBF252C1F936E0016E689 /* DispensaryRow.swift in Sources */,
@@ -317,7 +322,6 @@
 				478CFA772C27597C008C9CC5 /* logger.swift in Sources */,
 				47CA9C5A2C303D0B00C27BA8 /* DeveloperView.swift in Sources */,
 				4743D4962C3869B600183E19 /* Dispensary+CoreDataClass.swift in Sources */,
-				4743D4942C38691900183E19 /* DispensaryModel.xcdatamodeld in Sources */,
 				4743D4982C386A1900183E19 /* Dispensary+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -667,14 +671,13 @@
 /* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
-		4743D4922C38691900183E19 /* DispensaryModel.xcdatamodeld */ = {
+		D3A3CD102C42CED800060C53 /* DispensaryModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				4743D4932C38691900183E19 /* DispensaryModel.xcdatamodel */,
+				D3A3CD112C42CED800060C53 /* DispensaryModel.xcdatamodel */,
 			);
-			currentVersion = 4743D4932C38691900183E19 /* DispensaryModel.xcdatamodel */;
-			name = DispensaryModel.xcdatamodeld;
-			path = /Users/scottopell/dev/offdispmap/offdispmap/DispensaryModel.xcdatamodeld;
+			currentVersion = D3A3CD112C42CED800060C53 /* DispensaryModel.xcdatamodel */;
+			path = DispensaryModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/offdispmap/ContentView.swift
+++ b/offdispmap/ContentView.swift
@@ -52,33 +52,21 @@ struct WarningNotice: View {
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
+    @ObservedObject var viewModel: MainViewModel
     
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \DispensaryCoreData.name, ascending: true)],
-        animation: .default)
-    private var dispensaries: FetchedResults<DispensaryCoreData>
-    
-    @State private var selectedDispensary: Dispensary?
-    @State private var selectedAnnotation: DispensaryAnnotation?
-    @State private var hasFetched = false
-    @State private var isLoading = false
-    @State private var nycOnlyMode = true
-    @State private var deliveryOnlyMode = false
-    @State private var selectedTab = "map"
-    @State private var errorMessage: String?
     #if DEBUG
     @State private var showDeveloperView = false
     #endif
 
 
     var body: some View {
-        TabView(selection: $selectedTab) {
+        TabView(selection: $viewModel.selectedTab) {
             VStack(spacing: 10) {
                 headerView
-                if let err = errorMessage {
+                if let err = viewModel.errorMessage {
                     WarningNotice(warningMsg: err)
                 }
-                if isLoading {
+                if viewModel.isLoading {
                     fetchingDataView
                     Spacer()
                 } else {
@@ -95,10 +83,10 @@ struct ContentView: View {
 
             VStack(spacing: 20) {
                 headerView
-                if let err = errorMessage {
+                if let err = viewModel.errorMessage {
                     WarningNotice(warningMsg: err)
                 }
-                if isLoading {
+                if viewModel.isLoading {
                     fetchingDataView
                     Spacer()
                 } else {
@@ -119,11 +107,15 @@ struct ContentView: View {
         #endif
         .onAppear {
             let _ = LocationManager.shared
-            loadDataIfNeeded()
+            if viewModel.displayDispensaries.isEmpty { // So mock data works in the preview
+                Task { @MainActor in
+                    try await viewModel.fetchAndUpdateData()
+                }
+            }
         }
     }
     private var headerView: some View {
-        let place = nycOnlyMode ? "NYC" : "NY"
+        let place = viewModel.nycOnlyMode ? "NYC" : "NY"
         return Text(place + " Dispensaries")
             .font(.title)
             .fontWeight(.bold)
@@ -133,16 +125,16 @@ struct ContentView: View {
         HStack() {
             HStack() {
                 ForEach([
-                    ("NYC", dispCounts.nycArea),
-                    ("Delivery", dispCounts.deliveryOnly),
-                    ("Total", dispCounts.all)
+                    ("NYC", viewModel.dispCounts.nycArea),
+                    ("Delivery", viewModel.dispCounts.deliveryOnly),
+                    ("Total", viewModel.dispCounts.all)
                 ], id: \.0) { label, value in
                     StatCard(label: label, value: value)
                 }
             }
             Spacer()
             HStack() {
-                Toggle("NYC Only", isOn: $nycOnlyMode)
+                Toggle("NYC Only", isOn: $viewModel.nycOnlyMode)
                     .toggleStyle(SwitchToggleStyle(tint: .blue)).fixedSize()
                 #if DEBUG
                 Button(action: { showDeveloperView = true }) {
@@ -165,170 +157,55 @@ struct ContentView: View {
 
     private var mapView: some View {
         MapView(
-            annotations: dispensaryAnnotations,
-            selectedAnnotation: selectedAnnotation,
+            annotations: viewModel.dispensaryAnnotations,
+            selectedAnnotation: viewModel.selectedAnnotation,
             annotationFilter: { annotation in
-                    (self.nycOnlyMode ? annotation.dispensary.isNYC : true)
+                (viewModel.nycOnlyMode ? annotation.dispensary.isNYC : true)
             },
             onAnnotationSelect: { annotation in
-                selectDispensary(annotation.dispensary)
+                viewModel.selectDispensary(annotation.dispensary)
             })
     }
 
     private var selectedDispensaryView: some View {
         Group {
-            if let currentlySelectedDispensary = selectedDispensary {
+            if let currentlySelectedDispensary = viewModel.selectedDispensary {
                 DispensaryRow(dispensary: currentlySelectedDispensary, isSelected: true) {
-                    selectedDispensary = nil
-                    selectedAnnotation = nil
+                    viewModel.selectedDispensary = nil
+                    viewModel.selectedAnnotation = nil
                 }.padding(5)
             }
         }
     }
 
     private var dispensaryListView: some View {
-        let displayDispensaries = dispensaries.filter { dispensary in
-            if deliveryOnlyMode && dispensary.isTemporaryDeliveryOnly == false {
-                return false
-            }
-            if nycOnlyMode && dispensary.isNYC == false {
-                return false
-            }
-            return true
-        }.map { $0.toStruct }
         return VStack {
-            Toggle(isOn: $deliveryOnlyMode) {
+            Toggle(isOn: $viewModel.deliveryOnlyMode) {
                 Text("Delivery Only")
             }
-            if deliveryOnlyMode {
+            if viewModel.deliveryOnlyMode {
                 WarningNotice(warningMsg: "Who knows where these places deliver to? Just because its listed here doesn't mean it delivers to you. Duh.")
             }
-            List(displayDispensaries, id: \.name) { dispensary in
-                DispensaryRow(dispensary: dispensary, isSelected: dispensary.id == selectedDispensary?.id) {
-                    selectDispensary(dispensary)
+            List(viewModel.displayDispensaries, id: \.name) { dispensary in
+                DispensaryRow(dispensary: dispensary, isSelected: dispensary.id == viewModel.selectedDispensary?.id) {
+                    viewModel.selectDispensary(dispensary)
                 }
             }.listStyle(.plain)
         }
     }
     
-    private var dispensaryAnnotations: [DispensaryAnnotation] {
-        dispensaries.compactMap { dispensary in
-            guard let coordinate = dispensary.coordinate else { return nil }
-            guard nycOnlyMode == true && dispensary.isNYC == true else {
-                return nil
-            }
-            return DispensaryAnnotation(dispensary: dispensary.toStruct, name: dispensary.name, address: dispensary.fullAddress ?? "", coordinate: coordinate)
-        }
-    }
-    
-    private func loadDataIfNeeded() {
-        // TODO, if data has been recently fetched, then skip this
-        Task {
-            do {
-                try await fetchAndUpdateData()
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-    
-    private func fetchAndUpdateData() async throws {
-        let (dispensariesHTML, fetchedZipCodes) = try await (NetworkManager.shared.fetchDispensaryData(), NetworkManager.shared.fetchAllNYCZipCodes())
-        let parsedDispensaries = DataParser.parseDispensaryHTML(dispensariesHTML)
-        let nycZipCodes = Set(fetchedZipCodes)
-
-        for parsedDispensary in parsedDispensaries {
-            var isTemporaryDeliveryOnly = false
-            var name = parsedDispensary.name
-            if name.hasSuffix("***") {
-                name = name.replacingOccurrences(of: "***", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
-                isTemporaryDeliveryOnly = true
-            }
-            
-            if let dispensary = CoreDataManager.shared.createOrUpdateDispensary(
-                name: name,
-                address: parsedDispensary.address,
-                city: parsedDispensary.city,
-                zipCode: parsedDispensary.zipCode,
-                website: parsedDispensary.website,
-                isTemporaryDeliveryOnly: isTemporaryDeliveryOnly,
-                isNYC: nycZipCodes.contains(where: {$0 == parsedDispensary.zipCode})
-            ) {
-                if !isTemporaryDeliveryOnly {
-                    try await loadAddressForDispensary(dispensary)
-                }
-            }
-                
-            try? viewContext.save()
-        }
-    }
-    
-    private func loadAddressForDispensary(_ dispensary: DispensaryCoreData) async throws {
-        if dispensary.coordinate != nil {
-            return;
-        }
-        guard let fullAddress = dispensary.fullAddress else {
-            return;
-        }
-        if let coordinate = DispensaryData.shared.getCoordinate(for: fullAddress) {
-            dispensary.latitude = coordinate.latitude
-            dispensary.longitude = coordinate.longitude
-        } else {
-            Logger.info("Failed to lookup coordinate for '\(fullAddress)' in the map")
-            // If lookup fails, then this entry needs to be geocoded.
-            // If the geocoding fails, this dispensary is skipped
-            // This could result in incomplete listings,
-            // so TODO background periodic refresh.
-            if let coordinate = try await LocationManager.shared.geocodeFullAddress(fullAddress) {
-                dispensary.latitude = coordinate.latitude
-                dispensary.longitude = coordinate.longitude
-            }
-        }
-    }
-    
-    private var dispCounts: DispensaryCounts {
-        let allCount = dispensaries.count
-        let deliveryOnlyCount = deliveryOnlyDispensaries.count
-        let nycAreaCount = dispensaries.filter {$0.isNYC}.count
-        
-        return DispensaryCounts(
-            all: allCount,
-            deliveryOnly: deliveryOnlyCount,
-            nycArea: nycAreaCount
-        )
-    }
-    
-    private var deliveryOnlyDispensaries: [DispensaryCoreData] {
-        return dispensaries.filter {
-            $0.isTemporaryDeliveryOnly
-        }
-    }
-
-    private func selectDispensary(_ dispensary: Dispensary) {
-        selectedDispensary = dispensary
-        if dispensary.isTemporaryDeliveryOnly {
-            // This is currently not possible due to the UI code,
-            // however this case should be gracefully handled probably?
-            // Maybe I can refactor this out of existence
-            return;
-        }
-        if dispensary.coordinate == nil {
-            // This should be rare, but its when we loaded
-            // too many dispensaries whose addresses were not in
-            // the address cache and we got rate limited while
-            // geocoding
-            // maybe I can also refactor this out of existence
-            return;
-        }
-        Task {
-            if let annotation = dispensaryAnnotations.first(where: { $0.dispensary.id == dispensary.id }) {
-                selectedAnnotation = annotation
-                selectedTab = "map"
-            }
-        }
-    }
 }
 
 #Preview {
-    ContentView()
+    ContentView(viewModel: {
+        let vm = MainViewModel()
+        vm.displayDispensaries = [
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil)
+        ]
+        return vm
+    }())
 }

--- a/offdispmap/ContentViewiOS.swift
+++ b/offdispmap/ContentViewiOS.swift
@@ -9,72 +9,23 @@ import Foundation
 import SwiftUI
 import CoreData
 
-
-
 struct ContentViewiOS: View {
     
-    @Environment(\.managedObjectContext) private var viewContext
-    
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \DispensaryCoreData.name, ascending: true)],
-        animation: .default)
-    private var dispensaries: FetchedResults<DispensaryCoreData>
-    
-    @State private var selectedDispensary: Dispensary?
-    @State private var selectedAnnotation: DispensaryAnnotation?
-    @State var displayDispensaries: [Dispensary] = []
-    @State private var hasFetched = false
-    @State private var isLoading = false
-    @State private var nycOnlyMode = true
-    @State private var deliveryOnlyMode = false
-    @State private var selectedTab = "map"
-    @State private var errorMessage: String?
+    @ObservedObject var viewModel: MainViewModel
     @State private var selectedDetent = PresentationDetent.fraction(0.25)
     
     #if DEBUG
     @State private var showDeveloperView = false
     #endif
     
-    private var headerTitle: String {
-        let place = nycOnlyMode ? "NYC" : "NY"
-        return "\(place) Dispensaries"
-    }
-    
-    private var dispensaryAnnotations: [DispensaryAnnotation] {
-        dispensaries.compactMap { dispensary in
-            guard let coordinate = dispensary.coordinate else { return nil }
-            guard nycOnlyMode == true && dispensary.isNYC == true else {
-                return nil
-            }
-            return DispensaryAnnotation(dispensary: dispensary.toStruct, name: dispensary.name, address: dispensary.fullAddress ?? "", coordinate: coordinate)
-        }
-    }
-    
-    private var deliveryOnlyDispensaries: [DispensaryCoreData] {
-        return dispensaries.filter {
-            $0.isTemporaryDeliveryOnly
-        }
-    }
-    
-    private var dispCounts: DispensaryCounts {
-        let allCount = dispensaries.count
-        let deliveryOnlyCount = deliveryOnlyDispensaries.count
-        let nycAreaCount = dispensaries.filter {$0.isNYC}.count
-        
-        return DispensaryCounts(
-            all: allCount,
-            deliveryOnly: deliveryOnlyCount,
-            nycArea: nycAreaCount
-        )
-    }
     
     private var statisticsView: some View {
         VStack {
             HStack() {
                 ForEach([
-                    ("NYC", dispCounts.nycArea),
-                    ("Delivery", dispCounts.deliveryOnly),
-                    ("Total", dispCounts.all)
+                    ("NYC", viewModel.dispCounts.nycArea),
+                    ("Delivery", viewModel.dispCounts.deliveryOnly),
+                    ("Total", viewModel.dispCounts.all)
                 ], id: \.0) { label, value in
                     StatCard(label: label, value: value)
                 }
@@ -84,16 +35,16 @@ struct ContentViewiOS: View {
                 HStack() {
                     Text("NYC Only")
                     Spacer()
-                    Toggle("", isOn: $nycOnlyMode)
+                    Toggle("", isOn: $viewModel.nycOnlyMode)
                         .toggleStyle(SwitchToggleStyle(tint: .blue)).fixedSize()
                 }.lineLimit(1)
             }
             Divider()
-            Toggle(isOn: $deliveryOnlyMode) {
+            Toggle(isOn: $viewModel.deliveryOnlyMode) {
                 Text("Delivery Only")
             }
             
-            if deliveryOnlyMode {
+            if viewModel.deliveryOnlyMode {
                 WarningNotice(warningMsg: "Who knows where these places deliver to? Just because its listed here doesn't mean it delivers to you. Duh.")
             }
 #if DEBUG
@@ -111,14 +62,13 @@ struct ContentViewiOS: View {
     }
     
     private var dispensaryListView: some View {
-        
         return LazyVStack {
-            ForEach(displayDispensaries, id: \.name) { dispensary in
+            ForEach(viewModel.displayDispensaries) { dispensary in
                 Button(action: {
-                    selectDispensary(dispensary)
+                    viewModel.selectDispensary(dispensary)
                     selectedDetent = .fraction(0.25)
                 }) {
-                    DispensaryRow(dispensary: dispensary, isSelected: dispensary.id == selectedDispensary?.id)
+                    DispensaryRow(dispensary: dispensary, isSelected: dispensary.id == viewModel.selectedDispensary?.id)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(PlainButtonStyle())
@@ -130,20 +80,20 @@ struct ContentViewiOS: View {
     
     var body: some View {
             MapView(
-                annotations: dispensaryAnnotations,
-                selectedAnnotation: selectedAnnotation,
+                annotations: viewModel.dispensaryAnnotations,
+                selectedAnnotation: viewModel.selectedAnnotation,
                 annotationFilter: { annotation in
-                    (self.nycOnlyMode ? annotation.dispensary.isNYC : true)
+                    (viewModel.nycOnlyMode ? annotation.dispensary.isNYC : true)
                 },
                 onAnnotationSelect: { annotation in
-                    selectDispensary(annotation.dispensary)
+                    viewModel.selectDispensary(annotation.dispensary)
                 })
             .ignoresSafeArea()
             .sheet(isPresented: .constant(true)) {
                 ScrollView {
                     VStack {
                         HStack {
-                            Text(headerTitle)
+                            Text(viewModel.headerTitle)
                                 .font(.title3)
                                 .fontWeight(.bold)
                             Spacer()
@@ -166,61 +116,26 @@ struct ContentViewiOS: View {
                 }
             }
             .onAppear {
-                if displayDispensaries.isEmpty { // So the preview works
-                    reload()
+                let _ = LocationManager.shared
+                if viewModel.displayDispensaries.isEmpty { // So mock data works in the preview
+                    Task { @MainActor in
+                        try await viewModel.fetchAndUpdateData()
+                    }
                 }
             }
-            .onChange(of: nycOnlyMode) {
-                reload()
-            }
-            .onChange(of: deliveryOnlyMode) {
-                reload()
-            }
-    }
-    
-    private func selectDispensary(_ dispensary: Dispensary) {
-        selectedDispensary = dispensary
-        if dispensary.isTemporaryDeliveryOnly {
-            // This is currently not possible due to the UI code,
-            // however this case should be gracefully handled probably?
-            // Maybe I can refactor this out of existence
-            return;
-        }
-        if dispensary.coordinate == nil {
-            // This should be rare, but its when we loaded
-            // too many dispensaries whose addresses were not in
-            // the address cache and we got rate limited while
-            // geocoding
-            // maybe I can also refactor this out of existence
-            return;
-        }
-        Task {
-            if let annotation = dispensaryAnnotations.first(where: { $0.dispensary.id == dispensary.id }) {
-                selectedAnnotation = annotation
-                selectedTab = "map"
-            }
-        }
-    }
-    
-    func reload() {
-        displayDispensaries = dispensaries.filter { dispensary in
-            if deliveryOnlyMode && dispensary.isTemporaryDeliveryOnly == false {
-                return false
-            }
-            if nycOnlyMode && dispensary.isNYC == false {
-                return false
-            }
-            return true
-        }.map { $0.toStruct }
     }
 }
 
 #Preview {
-    ContentViewiOS(displayDispensaries: [
-        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
-        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
-        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
-        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
-        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil)
-    ])
+    ContentViewiOS(viewModel: {
+        let vm = MainViewModel()
+        vm.displayDispensaries = [
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+            Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil)
+        ]
+        return vm
+    }())
 }

--- a/offdispmap/ContentViewiOS.swift
+++ b/offdispmap/ContentViewiOS.swift
@@ -1,0 +1,226 @@
+//
+//  ContentViewiOS.swift
+//  offdispmap
+//
+//  Created by Brian Floersch on 7/13/24.
+//
+
+import Foundation
+import SwiftUI
+import CoreData
+
+
+
+struct ContentViewiOS: View {
+    
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \DispensaryCoreData.name, ascending: true)],
+        animation: .default)
+    private var dispensaries: FetchedResults<DispensaryCoreData>
+    
+    @State private var selectedDispensary: Dispensary?
+    @State private var selectedAnnotation: DispensaryAnnotation?
+    @State var displayDispensaries: [Dispensary] = []
+    @State private var hasFetched = false
+    @State private var isLoading = false
+    @State private var nycOnlyMode = true
+    @State private var deliveryOnlyMode = false
+    @State private var selectedTab = "map"
+    @State private var errorMessage: String?
+    @State private var selectedDetent = PresentationDetent.fraction(0.25)
+    
+    #if DEBUG
+    @State private var showDeveloperView = false
+    #endif
+    
+    private var headerTitle: String {
+        let place = nycOnlyMode ? "NYC" : "NY"
+        return "\(place) Dispensaries"
+    }
+    
+    private var dispensaryAnnotations: [DispensaryAnnotation] {
+        dispensaries.compactMap { dispensary in
+            guard let coordinate = dispensary.coordinate else { return nil }
+            guard nycOnlyMode == true && dispensary.isNYC == true else {
+                return nil
+            }
+            return DispensaryAnnotation(dispensary: dispensary.toStruct, name: dispensary.name, address: dispensary.fullAddress ?? "", coordinate: coordinate)
+        }
+    }
+    
+    private var deliveryOnlyDispensaries: [DispensaryCoreData] {
+        return dispensaries.filter {
+            $0.isTemporaryDeliveryOnly
+        }
+    }
+    
+    private var dispCounts: DispensaryCounts {
+        let allCount = dispensaries.count
+        let deliveryOnlyCount = deliveryOnlyDispensaries.count
+        let nycAreaCount = dispensaries.filter {$0.isNYC}.count
+        
+        return DispensaryCounts(
+            all: allCount,
+            deliveryOnly: deliveryOnlyCount,
+            nycArea: nycAreaCount
+        )
+    }
+    
+    private var statisticsView: some View {
+        VStack {
+            HStack() {
+                ForEach([
+                    ("NYC", dispCounts.nycArea),
+                    ("Delivery", dispCounts.deliveryOnly),
+                    ("Total", dispCounts.all)
+                ], id: \.0) { label, value in
+                    StatCard(label: label, value: value)
+                }
+            }
+            Divider()
+            HStack() {
+                HStack() {
+                    Text("NYC Only")
+                    Spacer()
+                    Toggle("", isOn: $nycOnlyMode)
+                        .toggleStyle(SwitchToggleStyle(tint: .blue)).fixedSize()
+                }.lineLimit(1)
+            }
+            Divider()
+            Toggle(isOn: $deliveryOnlyMode) {
+                Text("Delivery Only")
+            }
+            
+            if deliveryOnlyMode {
+                WarningNotice(warningMsg: "Who knows where these places deliver to? Just because its listed here doesn't mean it delivers to you. Duh.")
+            }
+#if DEBUG
+            Divider()
+            HStack {
+                Text("Developer")
+                Spacer()
+                Button(action: { showDeveloperView = true }) {
+                    Image(systemName: "hammer.fill")
+                        .foregroundColor(.blue)
+                }
+            }
+#endif
+        }
+    }
+    
+    private var dispensaryListView: some View {
+        
+        return LazyVStack {
+            ForEach(displayDispensaries, id: \.name) { dispensary in
+                Button(action: {
+                    selectDispensary(dispensary)
+                    selectedDetent = .fraction(0.25)
+                }) {
+                    DispensaryRow(dispensary: dispensary, isSelected: dispensary.id == selectedDispensary?.id)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(PlainButtonStyle())
+                Divider()
+
+            }.listStyle(.plain)
+        }
+    }
+    
+    var body: some View {
+            MapView(
+                annotations: dispensaryAnnotations,
+                selectedAnnotation: selectedAnnotation,
+                annotationFilter: { annotation in
+                    (self.nycOnlyMode ? annotation.dispensary.isNYC : true)
+                },
+                onAnnotationSelect: { annotation in
+                    selectDispensary(annotation.dispensary)
+                })
+            .ignoresSafeArea()
+            .sheet(isPresented: .constant(true)) {
+                ScrollView {
+                    VStack {
+                        HStack {
+                            Text(headerTitle)
+                                .font(.title3)
+                                .fontWeight(.bold)
+                            Spacer()
+                        }
+                        .padding(.horizontal)
+                        .padding(.top)
+                        
+                        statisticsView
+                            .padding(.horizontal)
+                        Divider()
+                        
+                        dispensaryListView
+                            .padding(.horizontal)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .presentationDetents([.fraction(0.25), .medium], selection: $selectedDetent)
+                            .presentationBackgroundInteraction(.enabled)
+                            .interactiveDismissDisabled()
+                            .presentationBackground(.thinMaterial)
+                    }
+                }
+            }
+            .onAppear {
+                if displayDispensaries.isEmpty { // So the preview works
+                    reload()
+                }
+            }
+            .onChange(of: nycOnlyMode) {
+                reload()
+            }
+            .onChange(of: deliveryOnlyMode) {
+                reload()
+            }
+    }
+    
+    private func selectDispensary(_ dispensary: Dispensary) {
+        selectedDispensary = dispensary
+        if dispensary.isTemporaryDeliveryOnly {
+            // This is currently not possible due to the UI code,
+            // however this case should be gracefully handled probably?
+            // Maybe I can refactor this out of existence
+            return;
+        }
+        if dispensary.coordinate == nil {
+            // This should be rare, but its when we loaded
+            // too many dispensaries whose addresses were not in
+            // the address cache and we got rate limited while
+            // geocoding
+            // maybe I can also refactor this out of existence
+            return;
+        }
+        Task {
+            if let annotation = dispensaryAnnotations.first(where: { $0.dispensary.id == dispensary.id }) {
+                selectedAnnotation = annotation
+                selectedTab = "map"
+            }
+        }
+    }
+    
+    func reload() {
+        displayDispensaries = dispensaries.filter { dispensary in
+            if deliveryOnlyMode && dispensary.isTemporaryDeliveryOnly == false {
+                return false
+            }
+            if nycOnlyMode && dispensary.isNYC == false {
+                return false
+            }
+            return true
+        }.map { $0.toStruct }
+    }
+}
+
+#Preview {
+    ContentViewiOS(displayDispensaries: [
+        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil),
+        Dispensary(name: "foo", website: "bar", latitude: 0, longitude: 0, isTemporaryDeliveryOnly: true, isNYC: true, url: nil, fullAddress: nil)
+    ])
+}

--- a/offdispmap/CoreDataManager.swift
+++ b/offdispmap/CoreDataManager.swift
@@ -37,8 +37,8 @@ class CoreDataManager {
         }
     }
     
-    func fetchDispensaries() -> [Dispensary] {
-        let request: NSFetchRequest<Dispensary> = Dispensary.fetchRequest()
+    func fetchDispensaries() -> [DispensaryCoreData] {
+        let request: NSFetchRequest<DispensaryCoreData> = DispensaryCoreData.fetchRequest()
         do {
             return try context.fetch(request)
         } catch {
@@ -55,18 +55,18 @@ class CoreDataManager {
         website: String,
         isTemporaryDeliveryOnly: Bool,
         isNYC: Bool
-    ) -> Dispensary? {
-        let fetchRequest: NSFetchRequest<Dispensary> = Dispensary.fetchRequest()
+    ) -> DispensaryCoreData? {
+        let fetchRequest: NSFetchRequest<DispensaryCoreData> = DispensaryCoreData.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "name == %@", name)
         
         do {
             let results = try context.fetch(fetchRequest)
-            let managedDispensary: Dispensary
+            let managedDispensary: DispensaryCoreData
             
             if let existingDispensary = results.first {
                 managedDispensary = existingDispensary
             } else {
-                managedDispensary = Dispensary(context: context)
+                managedDispensary = DispensaryCoreData(context: context)
             }
             
             // Update properties

--- a/offdispmap/DeveloperView.swift
+++ b/offdispmap/DeveloperView.swift
@@ -9,7 +9,7 @@ struct DeveloperView: View {
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \Dispensary.name, ascending: true)],
         animation: .default)
-    private var dispensaries: FetchedResults<Dispensary>
+    private var dispensaries: FetchedResults<DispensaryCoreData>
     
     @State private var uncachedDispensaryCoordinates: String = ""
     @State private var showingCopiedAlert = false
@@ -105,7 +105,7 @@ struct DeveloperView: View {
     }
 }
 
-func logUncachedCoordinates(_ dispensaries: [Dispensary], onlyNonCached: Bool) -> String {
+func logUncachedCoordinates(_ dispensaries: [DispensaryCoreData], onlyNonCached: Bool) -> String {
     var log = "let dispensaryCoordinates: [String: CLLocationCoordinate2D] = ["
     for dispensary in dispensaries {
         if let coordinate = dispensary.coordinate, let fullAddress = dispensary.fullAddress {

--- a/offdispmap/Dispensary+CoreDataClass.swift
+++ b/offdispmap/Dispensary+CoreDataClass.swift
@@ -10,6 +10,6 @@ import CoreData
 import CoreLocation
 
 @objc(Dispensary)
-public class Dispensary: NSManagedObject {
+public class DispensaryCoreData: NSManagedObject {
     // This will be empty for now
 }

--- a/offdispmap/Dispensary+CoreDataProperties.swift
+++ b/offdispmap/Dispensary+CoreDataProperties.swift
@@ -9,9 +9,42 @@ import Foundation
 import CoreData
 import CoreLocation
 
-extension Dispensary {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Dispensary> {
-        return NSFetchRequest<Dispensary>(entityName: "Dispensary")
+struct Dispensary: Identifiable {
+    
+    let id = UUID()
+    public var name: String
+    public var address: String?
+    public var city: String?
+    public var zipCode: String?
+    public var website: String
+    public var latitude: Double
+    public var longitude: Double
+    public var isTemporaryDeliveryOnly: Bool
+    public var isNYC: Bool
+    public var coordinate: CLLocationCoordinate2D?
+    public let url: URL?
+    public let fullAddress: String?
+    
+    init(name: String, address: String? = nil, city: String? = nil, zipCode: String? = nil, website: String, latitude: Double, longitude: Double, isTemporaryDeliveryOnly: Bool, isNYC: Bool, coordinate: CLLocationCoordinate2D? = nil, url: URL?, fullAddress: String?) {
+        self.name = name
+        self.address = address
+        self.city = city
+        self.zipCode = zipCode
+        self.website = website
+        self.latitude = latitude
+        self.longitude = longitude
+        self.isTemporaryDeliveryOnly = isTemporaryDeliveryOnly
+        self.isNYC = isNYC
+        self.coordinate = coordinate
+        self.url = url
+        self.fullAddress = fullAddress
+    }
+}
+
+extension DispensaryCoreData {
+    
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DispensaryCoreData> {
+        return NSFetchRequest<DispensaryCoreData>(entityName: "Dispensary")
     }
 
     @NSManaged public var name: String
@@ -54,6 +87,10 @@ extension Dispensary {
         set {
             // no-op
         }
+    }
+    
+    var toStruct: Dispensary {
+        Dispensary(name: name, website: website, latitude: latitude, longitude: longitude, isTemporaryDeliveryOnly: isTemporaryDeliveryOnly, isNYC: isNYC, url: url, fullAddress: fullAddress)
     }
 }
 

--- a/offdispmap/DispensaryRow.swift
+++ b/offdispmap/DispensaryRow.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct DispensaryRow: View {
     var dispensary: Dispensary
     var isSelected: Bool = false
-    var onSelect: () -> Void
+    var onSelect: (() -> Void)? = nil
     
     @State private var presentSafari = false
 
@@ -55,18 +55,20 @@ struct DispensaryRow: View {
                 
             }
             Spacer()
-            VStack {
-                Group {
-                    if isSelected {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.red)
-                    } else {
-                        if !dispensary.isTemporaryDeliveryOnly {
-                            Image(systemName: "location.magnifyingglass").foregroundColor(.blue)
+            if let onSelect = onSelect {
+                VStack {
+                    Group {
+                        if isSelected {
+                            Image(systemName: "xmark.circle.fill").foregroundColor(.red)
+                        } else {
+                            if !dispensary.isTemporaryDeliveryOnly {
+                                Image(systemName: "location.magnifyingglass").foregroundColor(.blue)
+                            }
                         }
                     }
-                }
-                .onTapGesture {
-                    onSelect()
+                    .onTapGesture {
+                        onSelect()
+                    }
                 }
             }
         }

--- a/offdispmap/MainViewModel.swift
+++ b/offdispmap/MainViewModel.swift
@@ -1,0 +1,160 @@
+//
+//  MainViewModel.swift
+//  offdispmap
+//
+//  Created by Brian Floersch on 7/14/24.
+//
+
+import Foundation
+import CoreData
+import Combine
+
+@MainActor
+class MainViewModel: ObservableObject {
+    @Published var selectedDispensary: Dispensary?
+    @Published var selectedAnnotation: DispensaryAnnotation?
+    @Published var displayDispensaries: [Dispensary] = []
+    @Published var hasFetched = false
+    @Published var isLoading = false
+    @Published var nycOnlyMode = true
+    @Published var deliveryOnlyMode = false
+    @Published var selectedTab = "map"
+    @Published var errorMessage: String?
+    
+    func fetchDispensaries() {
+        dispensaries = CoreDataManager.shared.fetchDispensaries()
+    }
+    
+    var dispensaries: [DispensaryCoreData] = [] {
+        didSet {
+            displayDispensaries = dispensaries.filter { dispensary in
+                if deliveryOnlyMode && dispensary.isTemporaryDeliveryOnly == false {
+                    return false
+                }
+                if nycOnlyMode && dispensary.isNYC == false {
+                    return false
+                }
+                return true
+            }.map { $0.toStruct }
+        }
+    }
+    
+    
+    var headerTitle: String {
+        let place = nycOnlyMode ? "NYC" : "NY"
+        return "\(place) Dispensaries"
+    }
+    
+    var dispensaryAnnotations: [DispensaryAnnotation] {
+        dispensaries.compactMap { dispensary in
+            guard let coordinate = dispensary.coordinate else { return nil }
+            guard nycOnlyMode == true && dispensary.isNYC == true else {
+                return nil
+            }
+            return DispensaryAnnotation(dispensary: dispensary.toStruct, name: dispensary.name, address: dispensary.fullAddress ?? "", coordinate: coordinate)
+        }
+    }
+    
+    var deliveryOnlyDispensaries: [DispensaryCoreData] {
+        return dispensaries.filter {
+            $0.isTemporaryDeliveryOnly
+        }
+    }
+    
+    var dispCounts: DispensaryCounts {
+        let allCount = dispensaries.count
+        let deliveryOnlyCount = deliveryOnlyDispensaries.count
+        let nycAreaCount = dispensaries.filter {$0.isNYC}.count
+        
+        return DispensaryCounts(
+            all: allCount,
+            deliveryOnly: deliveryOnlyCount,
+            nycArea: nycAreaCount
+        )
+    }
+    
+    func loadDataIfNeeded() async throws {
+        do {
+            try await fetchAndUpdateData()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func fetchAndUpdateData() async throws {
+        let (dispensariesHTML, fetchedZipCodes) = try await (NetworkManager.shared.fetchDispensaryData(), NetworkManager.shared.fetchAllNYCZipCodes())
+        let parsedDispensaries = DataParser.parseDispensaryHTML(dispensariesHTML)
+        let nycZipCodes = Set(fetchedZipCodes)
+        
+        for parsedDispensary in parsedDispensaries {
+            var isTemporaryDeliveryOnly = false
+            var name = parsedDispensary.name
+            if name.hasSuffix("***") {
+                name = name.replacingOccurrences(of: "***", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+                isTemporaryDeliveryOnly = true
+            }
+            
+            if let dispensary = CoreDataManager.shared.createOrUpdateDispensary(
+                name: name,
+                address: parsedDispensary.address,
+                city: parsedDispensary.city,
+                zipCode: parsedDispensary.zipCode,
+                website: parsedDispensary.website,
+                isTemporaryDeliveryOnly: isTemporaryDeliveryOnly,
+                isNYC: nycZipCodes.contains(where: {$0 == parsedDispensary.zipCode})
+            ) {
+                if !isTemporaryDeliveryOnly {
+                    try await loadAddressForDispensary(dispensary)
+                }
+            }
+        }
+        fetchDispensaries()
+    }
+        
+    private func loadAddressForDispensary(_ dispensary: DispensaryCoreData) async throws {
+        if dispensary.coordinate != nil {
+            return;
+        }
+        guard let fullAddress = dispensary.fullAddress else {
+            return;
+        }
+        if let coordinate = DispensaryData.shared.getCoordinate(for: fullAddress) {
+            dispensary.latitude = coordinate.latitude
+            dispensary.longitude = coordinate.longitude
+        } else {
+            Logger.info("Failed to lookup coordinate for '\(fullAddress)' in the map")
+            // If lookup fails, then this entry needs to be geocoded.
+            // If the geocoding fails, this dispensary is skipped
+            // This could result in incomplete listings,
+            // so TODO background periodic refresh.
+            if let coordinate = try await LocationManager.shared.geocodeFullAddress(fullAddress) {
+                dispensary.latitude = coordinate.latitude
+                dispensary.longitude = coordinate.longitude
+            }
+        }
+    }
+    
+    func selectDispensary(_ dispensary: Dispensary) {
+        selectedDispensary = dispensary
+        if dispensary.isTemporaryDeliveryOnly {
+            // This is currently not possible due to the UI code,
+            // however this case should be gracefully handled probably?
+            // Maybe I can refactor this out of existence
+            return;
+        }
+        if dispensary.coordinate == nil {
+            // This should be rare, but its when we loaded
+            // too many dispensaries whose addresses were not in
+            // the address cache and we got rate limited while
+            // geocoding
+            // maybe I can also refactor this out of existence
+            return;
+        }
+        if let annotation = dispensaryAnnotations.first(where: { $0.dispensary.id == dispensary.id }) {
+            selectedAnnotation = annotation
+            selectedTab = "map"
+        }
+    }
+    
+    
+}

--- a/offdispmap/offdispmapApp.swift
+++ b/offdispmap/offdispmapApp.swift
@@ -13,8 +13,14 @@ struct offdispmapApp: App {
 
     var body: some Scene {  
         WindowGroup {
-           ContentView()
-               .environment(\.managedObjectContext, persistenceController.context)
+        #if os(iOS)
+            ContentViewiOS()
+                .environment(\.managedObjectContext, persistenceController.context)
+        #else
+            ContentView()
+                .environment(\.managedObjectContext, persistenceController.context)
+        #endif
+           
        }
     }
 }

--- a/offdispmap/offdispmapApp.swift
+++ b/offdispmap/offdispmapApp.swift
@@ -14,10 +14,10 @@ struct offdispmapApp: App {
     var body: some Scene {  
         WindowGroup {
         #if os(iOS)
-            ContentViewiOS()
+            ContentViewiOS(viewModel: MainViewModel())
                 .environment(\.managedObjectContext, persistenceController.context)
         #else
-            ContentView()
+            ContentView(viewModel: MainViewModel())
                 .environment(\.managedObjectContext, persistenceController.context)
         #endif
            


### PR DESCRIPTION
Just wanted to play around - so I created a new content view designed specifically for iOS control elements. The original view remains working. (I haven't tested that everything works right) so feel free to use this as inspiration or just throw it away 🤷 

Changes:
- Fix build - coredata schema was excluded due to absolute path
- decouple SwiftUI view data from coredata (SwiftUI likes structs) 
- Make preview work with mock data (in both `ContentView` and `ContentViewiOS`)
- Bottom sheet style navigation
- Change tap behavior of list view to use the whole element 
- Added  `MainViewModel` to share view data between implementations (and split view logic from data logic) 


<img width="515" alt="image" src="https://github.com/user-attachments/assets/13069e84-8b2a-4c4a-a66f-45d27a02220f">

<img width="559" alt="image" src="https://github.com/user-attachments/assets/148ea5ee-42db-49f1-be55-3083591bd5a5">
